### PR TITLE
Renamed 2 methods (execute and execute_with_result) and fixed small bug

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -96,7 +96,7 @@ class SQLQueue:
         cursor = self.__immediate_connection.cursor(dictionary=True, buffered=True)
         cursor.execute(query, parameters)
 
-        if cursor.rowcount == 0:
+        if not cursor.with_rows:
             return {}
 
         if fetch_all:
@@ -143,7 +143,7 @@ class SQLQueue:
         logger.debug(f"Executing the query {query} with parameters {parameters} ")
         cursor.execute(query, parameters)
 
-        if cursor.rowcount == 0:
+        if not cursor.with_rows:
             self.__immediate_connection.commit()
             return {}
 
@@ -169,7 +169,7 @@ class SQLQueue:
             cursor = connection.cursor(dictionary=True, buffered=True)
             cursor.execute(query['query'], query['parameters'])
 
-            if cursor.rowcount == 0:
+            if not cursor.with_rows:
                 result = {}
             else:
                 result = cursor.fetchall()

--- a/backend/database.py
+++ b/backend/database.py
@@ -9,7 +9,7 @@ import mysql.connector
 import mysql.connector.pooling
 
 from deprecation import deprecated
-from exception import InvalidArgumentException, ProgramClosingException, SingletonException
+from exceptions import InvalidArgumentException, ProgramClosingException, SingletonException
 
 POOL_SIZE = 5
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -97,12 +97,14 @@ class SQLQueue:
         cursor.execute(query, parameters)
 
         if not cursor.with_rows:
-            return {}
+            result = {}
+        elif fetch_all:
+            result = cursor.fetchall()
+        else:
+            result = cursor.fetchone()
 
-        if fetch_all:
-            return cursor.fetchall()
-
-        return cursor.fetchone()
+        self.__immediate_connection.commit()
+        return result
 
     @deprecated("Changed name to execute_async")
     def execute(self, query: str, parameters: Iterable = None,


### PR DESCRIPTION
+ Renamed execute to execute_async
+ Renamed execute_with_result to execute_sync
+ Added deprecated decorator to execute and execute_with_result
+ Fixed bug caused by ternary operator